### PR TITLE
feat: add deployment to Cloudflare Pages in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     name: Web CI
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      deployments: write
     env:
       ASTRO_TELEMETRY_DISABLED: "1"
     defaults:
@@ -72,3 +75,22 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          wranglerVersion: "4.63.0"
+          workingDirectory: apps/web
+          packageManager: pnpm
+          command: pages deploy dist --project-name=${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }} --branch=main
+
+      - name: Show deployment URL
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          echo "Deployment URL: ${{ steps.deploy.outputs.deployment-url }}"
+          echo "Deployment Alias: ${{ steps.deploy.outputs.pages-deployment-alias-url }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      deployments: write
     env:
       ASTRO_TELEMETRY_DISABLED: "1"
     defaults:
@@ -76,10 +75,52 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Deploy to Cloudflare Pages
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: web
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: read
+      deployments: write
+    env:
+      ASTRO_TELEMETRY_DISABLED: "1"
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify metadata reproducibility
+        run: |
+          pnpm gen:meta
+          git diff --exit-code
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy
         id: deploy
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -90,7 +131,6 @@ jobs:
           command: pages deploy dist --project-name=${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }} --branch=main
 
       - name: Show deployment URL
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           echo "Deployment URL: ${{ steps.deploy.outputs.deployment-url }}"
           echo "Deployment Alias: ${{ steps.deploy.outputs.pages-deployment-alias-url }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD ワークフローに Cloudflare Pages への自動デプロイを追加しました。メインブランチへのプッシュ後にビルドとデプロイが順次実行され、デプロイ結果の公開 URL と別名が表示されます。ワークフロー実行権限やセットアップ手順も更新され、安定した自動デプロイを実現します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->