### PR TITLE
Escape HTML in Mermaid code blocks and add renderMermaidHtml tests

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -1,27 +1,12 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import { renderMermaidHtml } from './src/lib/markdown/mermaid-html.ts';
 
 /**
  * @typedef {{ type: string, children?: RemarkNode[] }} RemarkNode
  * @typedef {RemarkNode & { type: 'root', children: RemarkNode[] }} RemarkRoot
  * @typedef {RemarkNode & { type: 'code', lang?: string, value: string, meta?: string }} RemarkCode
  */
-
-/**
- * @param {string} value
- * @returns {string}
- */
-export function escapeHtmlText(value) {
-  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-}
-
-/**
- * @param {string} source
- * @returns {string}
- */
-export function renderMermaidHtml(source) {
-  return `<div class="mermaid">${escapeHtmlText(source)}</div>`;
-}
 
 export function remarkMermaid() {
   /**

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -7,7 +7,23 @@ import { defineConfig } from 'astro/config';
  * @typedef {RemarkNode & { type: 'code', lang?: string, value: string, meta?: string }} RemarkCode
  */
 
-function remarkMermaid() {
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+export function escapeHtmlText(value) {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+/**
+ * @param {string} source
+ * @returns {string}
+ */
+export function renderMermaidHtml(source) {
+  return `<div class="mermaid">${escapeHtmlText(source)}</div>`;
+}
+
+export function remarkMermaid() {
   /**
    * @param {RemarkRoot} tree
    */
@@ -35,10 +51,9 @@ function remarkMermaid() {
      * @param {RemarkCode} node
      */
     toReplace.forEach((node) => {
-      const mermaidSource = node.value.replaceAll('\n', '<br/>');
       Object.assign(node, {
         type: 'html',
-        value: `<div class="mermaid">${mermaidSource}</div>`,
+        value: renderMermaidHtml(node.value),
         lang: undefined,
         meta: undefined,
         children: undefined,

--- a/apps/web/src/lib/markdown/mermaid-html.test.ts
+++ b/apps/web/src/lib/markdown/mermaid-html.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+const { renderMermaidHtml } = (await import('../../../astro.config.mjs')) as {
+  renderMermaidHtml: (source: string) => string;
+};
+
+describe('renderMermaidHtml', () => {
+  it('keeps Mermaid line breaks as text instead of converting them to HTML breaks', () => {
+    const html = renderMermaidHtml('flowchart TB\n  A --> B');
+
+    expect(html).toContain('flowchart TB\n  A --&gt; B');
+    expect(html).not.toContain('flowchart TB<br');
+  });
+
+  it('escapes HTML syntax while preserving Mermaid label HTML as text for the parser', () => {
+    const html = renderMermaidHtml('A["ローカル開発<br/>pnpm dev"] --> B');
+
+    expect(html).toBe('<div class="mermaid">A["ローカル開発&lt;br/&gt;pnpm dev"] --&gt; B</div>');
+  });
+});

--- a/apps/web/src/lib/markdown/mermaid-html.test.ts
+++ b/apps/web/src/lib/markdown/mermaid-html.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-const { renderMermaidHtml } = (await import('../../../astro.config.mjs')) as {
-  renderMermaidHtml: (source: string) => string;
-};
+import { renderMermaidHtml } from './mermaid-html';
 
 describe('renderMermaidHtml', () => {
   it('keeps Mermaid line breaks as text instead of converting them to HTML breaks', () => {

--- a/apps/web/src/lib/markdown/mermaid-html.ts
+++ b/apps/web/src/lib/markdown/mermaid-html.ts
@@ -1,0 +1,14 @@
+/**
+ * Escapes text so Mermaid source can be embedded inside HTML without creating
+ * markup that runs before Mermaid parses it.
+ */
+export function escapeHtmlText(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+/**
+ * Renders Mermaid source as escaped inline HTML for Astro's Markdown pipeline.
+ */
+export function renderMermaidHtml(source: string): string {
+  return `<div class="mermaid">${escapeHtmlText(source)}</div>`;
+}


### PR DESCRIPTION
### Motivation

- Ensure Mermaid code blocks are rendered safely by escaping HTML characters and preserving original line breaks so the Mermaid parser receives the intended source.

### Description

- Add exported helpers `escapeHtmlText` and `renderMermaidHtml` in `astro.config.mjs` to escape `&`, `<`, and `>` and wrap the source in a `<div class="mermaid">`.
- Update `remarkMermaid` to use `renderMermaidHtml` instead of converting newlines to `<br/>` so line breaks remain part of the Mermaid source.
- Export the rendering helper so it can be imported by tests.

### Testing

- Added `apps/web/src/lib/markdown/mermaid-html.test.ts` with Vitest unit tests that assert line breaks are preserved and HTML syntax is escaped correctly for the parser.
- Ran `vitest` and the new tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2676ef163c8328a132a8904ca70d62)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Mermaidダイアグラムのレンダリング処理を改善し、HTML処理の正確性を向上させました。

* **Tests**
  * Mermaidレンダリング機能のテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->